### PR TITLE
Instability code update

### DIFF
--- a/src/main/java/mrjake/aunis/config/AunisConfig.java
+++ b/src/main/java/mrjake/aunis/config/AunisConfig.java
@@ -72,7 +72,7 @@ public class AunisConfig {
 		@RangeInt(min=0)
 		public int keepAliveBlockToEnergyRatioPerTick = 2;
 
-		@Name("Stargate instability threshold(seconds to close)")
+		@Name("Stargate instability threshold (seconds of energy left before gate becomes unstable)")
 		@RangeInt(min=1)
 		public int instabilitySeconds = 20;
 		

--- a/src/main/java/mrjake/aunis/tileentity/stargate/StargateAbstractBaseTile.java
+++ b/src/main/java/mrjake/aunis/tileentity/stargate/StargateAbstractBaseTile.java
@@ -694,20 +694,24 @@ public abstract class StargateAbstractBaseTile extends TileEntity implements Sta
 				energySecondsToClose = energyStored/(float)keepAliveEnergyPerTick / 20f;
 				
 				if (energySecondsToClose >= 1) {
+					
 					/*
 					 * If energy can sustain connection for less than AunisConfig.powerConfig.instabilitySeconds seconds
 					 * Start flickering
+					 * 
+					 * 2020-04-25: changed the below to check if the gate is being sufficiently externally powered and, if so,
+					 * do not start flickering even if the internal power isn't enough.
 					 */
 					
 					// Horizon becomes unstable
-					if (horizonFlashTask == null && energySecondsToClose < AunisConfig.powerConfig.instabilitySeconds) {
+					if (horizonFlashTask == null && energySecondsToClose < AunisConfig.powerConfig.instabilitySeconds && energyTransferedLastTick < 0) {
 						resetFlashingSequence();
 						
 						setHorizonFlashTask(new ScheduledTask(EnumScheduledTask.HORIZON_FLASH, (int) (Math.random() * 40) + 5));
 					}
 					
 					// Horizon becomes stable
-					if (horizonFlashTask != null && energySecondsToClose > AunisConfig.powerConfig.instabilitySeconds) {
+					if (horizonFlashTask != null && (energySecondsToClose > AunisConfig.powerConfig.instabilitySeconds || energyTransferedLastTick >= 0)) {
 						horizonFlashTask = null;
 						isCurrentlyUnstable = false;
 						


### PR DESCRIPTION
Instability code now checks to see if external power is sufficient
enough to maintain wormhole and, if so, the gate doesn't flicker when
reaching the instability threshold. Also clarified in the config that
this threshold decides when the gate begins to flicker and not the
maximum wormhole opening time.