### PR TITLE
fix: regenerate addressess and update merge state when gate position changes

### DIFF
--- a/src/main/java/mrjake/aunis/tileentity/stargate/StargateClassicBaseTile.java
+++ b/src/main/java/mrjake/aunis/tileentity/stargate/StargateClassicBaseTile.java
@@ -180,12 +180,23 @@ public abstract class StargateClassicBaseTile extends StargateAbstractBaseTile i
 			updatePowerTier();
 		}
 	}
+
+	private BlockPos lastPos = BlockPos.ORIGIN;
 	
 	@Override
 	public void update() {
 		super.update();
 		
 		if (!world.isRemote) {
+			if (!lastPos.equals(pos)) {
+        lastPos = pos;
+        generateAddresses(!hasUpgrade(StargateClassicBaseTile.StargateUpgradeEnum.CHEVRON_UPGRADE));
+
+        if (isMerged()) {
+          updateMergeState(onGateMergeRequested(), facing);
+        }
+      }
+
 			if (givePageTask != null) {
 				if (givePageTask.update(world.getTotalWorldTime())) {
 					givePageTask = null;


### PR DESCRIPTION
This PR should fix issues when moving the gate by using mods like WarpDrive, Valkyrien etc.

Nine chevron address stays the same when the gate moves and seven chevron address regenerates.

Fixes #253 