### PR TITLE
fix: accept connections even when dialing

### DIFF
--- a/src/main/java/mrjake/aunis/tileentity/stargate/StargateAbstractBaseTile.java
+++ b/src/main/java/mrjake/aunis/tileentity/stargate/StargateAbstractBaseTile.java
@@ -183,7 +183,7 @@ public abstract class StargateAbstractBaseTile extends TileEntity implements Sta
 	protected void onGateMerged() {}
 	
 	public boolean canAcceptConnectionFrom(StargatePos targetGatePos) {
-		return isMerged && stargateState.idle();
+		return isMerged && (stargateState.idle() || stargateState.dialing() || stargateState.dialingComputer());
 	}
 		
 	protected void sendRenderingUpdate(EnumGateAction gateAction, int chevronCount, boolean modifyFinal) {


### PR DESCRIPTION
Stargates should accept connections regardless of the dialing state, as it was in the show.